### PR TITLE
Allow r/w of SecretData<T>

### DIFF
--- a/src/VaultSharp/V1/Commons/SecretData.cs
+++ b/src/VaultSharp/V1/Commons/SecretData.cs
@@ -6,7 +6,11 @@ namespace VaultSharp.V1.Commons
     /// <summary>
     /// Represents a Vault Secret Data.
     /// </summary>
-    public class SecretData
+    public class SecretData : SecretData<IDictionary<string, object>>
+    {
+    }
+
+    public class SecretData<T>
     {
         /// <summary>
         /// Gets or sets the data.
@@ -15,7 +19,7 @@ namespace VaultSharp.V1.Commons
         /// The data.
         /// </value>
         [JsonProperty("data")]
-        public Dictionary<string, object> Data { get; set; }
+        public T Data { get; set; }
 
         /// <summary>
         /// Gets or sets the metadata.

--- a/src/VaultSharp/V1/SecretsEngines/KeyValue/V1/IKeyValueSecretsEngineV1.cs
+++ b/src/VaultSharp/V1/SecretsEngines/KeyValue/V1/IKeyValueSecretsEngineV1.cs
@@ -27,6 +27,23 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V1
         Task<Secret<Dictionary<string, object>>> ReadSecretAsync(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValueV1, string wrapTimeToLive = null);
 
         /// <summary>
+        /// Retrieves the secret at the specified location.
+        /// </summary>
+        /// <param name="path"><para>[required]</para>
+        /// The location path where the secret needs to be read from.</param>
+        /// <param name="mountPoint"><para>[optional]</para>
+        /// The mount point for the KeyValue backend. Defaults to <see cref="SecretsEngineDefaultPaths.KeyValueV1" />
+        /// Provide a value only if you have customized the mount point.</param>
+        /// <param name="wrapTimeToLive">
+        /// <para>[required]</para>
+        /// The TTL for the token and can be either an integer number of seconds or a string duration of seconds.
+        /// </param>
+        /// <returns>
+        /// The secret with the data.
+        /// </returns>
+        Task<Secret<T>> ReadSecretAsync<T>(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValueV1, string wrapTimeToLive = null);
+        
+        /// <summary>
         /// Retrieves the secret location path entries at the specified location.
         /// Folders are suffixed with /. The input must be a folder; list on a file will not return a value. 
         /// The values themselves are not accessible via this API.
@@ -70,6 +87,31 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V1
         /// </remarks>
         Task WriteSecretAsync(string path, IDictionary<string, object> values, string mountPoint = SecretsEngineDefaultPaths.KeyValueV1);
 
+        /// <summary>
+        /// Stores a secret at the specified location. If the value does not yet exist, the calling token must have an ACL policy granting the create capability. 
+        /// If the value already exists, the calling token must have an ACL policy granting the update capability.
+        /// </summary>
+        /// <param name="path"><para>[required]</para>
+        /// The path where the value is to be stored.</param>
+        /// <param name="values"><para>[required]</para>
+        /// The value to be written.</param>
+        /// <param name="mountPoint"><para>[optional]</para>
+        /// The mount point for the Generic backend. Defaults to <see cref="SecretsEngineDefaultPaths.KeyValueV1" />
+        /// Provide a value only if you have customized the mount point.
+        /// </param>
+        /// <returns>
+        /// The task.
+        /// </returns>
+        /// <remarks>
+        /// Unlike other secrets engines, the KV secrets engine does not enforce TTLs for expiration. 
+        /// Instead, the lease_duration is a hint for how often consumers should check back for a new value. 
+        /// This is commonly displayed as refresh_interval instead of lease_duration to clarify this in output.
+        /// If provided a key of ttl, the KV secrets engine will utilize this value as the lease duration:
+        /// Even with a ttl set, the secrets engine never removes data on its own.The ttl key is merely advisory.
+        /// When reading a value with a ttl, both the ttl key and the refresh interval will reflect the value:
+        /// </remarks>
+        Task WriteSecretAsync<T>(string path, T values, string mountPoint = SecretsEngineDefaultPaths.KeyValueV1);
+        
         /// <summary>
         /// Deletes the value at the specified path in Vault.
         /// </summary>

--- a/src/VaultSharp/V1/SecretsEngines/KeyValue/V1/KeyValueSecretsEngineV1Provider.cs
+++ b/src/VaultSharp/V1/SecretsEngines/KeyValue/V1/KeyValueSecretsEngineV1Provider.cs
@@ -17,10 +17,15 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V1
 
         public async Task<Secret<Dictionary<string, object>>> ReadSecretAsync(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValueV1, string wrapTimeToLive = null)
         {
+            return await ReadSecretAsync<Dictionary<string, object>>(path, mountPoint, wrapTimeToLive);
+        }
+        
+        public async Task<Secret<T>> ReadSecretAsync<T>(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValueV1, string wrapTimeToLive = null)
+        {
             Checker.NotNull(mountPoint, "mountPoint");
             Checker.NotNull(path, "path");
 
-            return await _polymath.MakeVaultApiRequest<Secret<Dictionary<string, object>>>("v1/" + mountPoint.Trim('/') + "/" + path.Trim('/'), HttpMethod.Get, wrapTimeToLive: wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+            return await _polymath.MakeVaultApiRequest<Secret<T>>("v1/" + mountPoint.Trim('/') + "/" + path.Trim('/'), HttpMethod.Get, wrapTimeToLive: wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
         }
 
         public async Task<Secret<ListInfo>> ReadSecretPathsAsync(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValueV1, string wrapTimeToLive = null)
@@ -32,6 +37,11 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V1
         }
 
         public async Task WriteSecretAsync(string path, IDictionary<string, object> values, string mountPoint = SecretsEngineDefaultPaths.KeyValueV1)
+        {
+            await WriteSecretAsync(path, values, mountPoint);
+        }
+        
+        public async Task WriteSecretAsync<T>(string path, T values, string mountPoint = SecretsEngineDefaultPaths.KeyValueV1)
         {
             Checker.NotNull(mountPoint, "mountPoint");
             Checker.NotNull(path, "path");

--- a/src/VaultSharp/V1/SecretsEngines/KeyValue/V2/IKeyValueSecretsEngineV2.cs
+++ b/src/VaultSharp/V1/SecretsEngines/KeyValue/V2/IKeyValueSecretsEngineV2.cs
@@ -30,6 +30,28 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V2
         /// The secret with the data.
         /// </returns>
         Task<Secret<SecretData>> ReadSecretAsync(string path, int? version = null, string mountPoint = SecretsEngineDefaultPaths.KeyValueV2, string wrapTimeToLive = null);
+        
+        /// <summary>
+        /// Retrieves the secret at the specified location.
+        /// </summary>
+        /// <param name="path"><para>[required]</para>
+        /// The location path where the secret needs to be read from.</param>
+        /// The mount point for the KeyValue backend. Defaults to <see cref="SecretsEngineDefaultPaths.KeyValueV2" />
+        /// Provide a value only if you have customized the mount point.</param>
+        /// <param name="version"><para>[optional]</para>
+        /// Specifies the version to return. If not set the latest version is returned.
+        /// </param>
+        /// <param name="mountPoint"><para>[optional]</para>
+        /// The mount point for the KeyValue backend. Defaults to <see cref="SecretsEngineDefaultPaths.KeyValue" />
+        /// Provide a value only if you have customized the mount point.</param>
+        /// <param name="wrapTimeToLive">
+        /// <para>[required]</para>
+        /// The TTL for the token and can be either an integer number of seconds or a string duration of seconds.
+        /// </param>
+        /// <returns>
+        /// The secret with the data.
+        /// </returns>
+        Task<Secret<SecretData<T>>> ReadSecretAsync<T>(string path, int? version = null, string mountPoint = SecretsEngineDefaultPaths.KeyValueV2, string wrapTimeToLive = null);
 
         /// <summary>
         /// Retrieves the secret location path entries at the specified location.
@@ -98,6 +120,36 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V2
         /// When reading a value with a ttl, both the ttl key and the refresh interval will reflect the value:
         /// </remarks>
         Task WriteSecretAsync(string path, IDictionary<string, object> data, int? checkAndSet = null, string mountPoint = SecretsEngineDefaultPaths.KeyValueV2);
+        
+        /// <summary>
+        /// Stores a secret at the specified location. If the value does not yet exist, the calling token must have an ACL policy granting the create capability. 
+        /// If the value already exists, the calling token must have an ACL policy granting the update capability.
+        /// </summary>
+        /// <param name="path"><para>[required]</para>
+        /// The path where the value is to be stored.</param>
+        /// <param name="data"><para>[required]</para>
+        /// The value to be written.</param>
+        /// <param name="checkAndSet">
+        /// <para>[optional]</para>
+        /// If not set the write will be allowed. If set to 0 a write will only be allowed if the key doesn’t exist. 
+        /// If the index is non-zero the write will only be allowed if the key’s current version matches the version specified in the cas parameter.
+        /// </param>
+        /// <param name="mountPoint"><para>[optional]</para>
+        /// The mount point for the Generic backend. Defaults to <see cref="SecretsEngineDefaultPaths.KeyValueV2" />
+        /// Provide a value only if you have customized the mount point.
+        /// </param>
+        /// <returns>
+        /// The task.
+        /// </returns>
+        /// <remarks>
+        /// Unlike other secrets engines, the KV secrets engine does not enforce TTLs for expiration. 
+        /// Instead, the lease_duration is a hint for how often consumers should check back for a new value. 
+        /// This is commonly displayed as refresh_interval instead of lease_duration to clarify this in output.
+        /// If provided a key of ttl, the KV secrets engine will utilize this value as the lease duration:
+        /// Even with a ttl set, the secrets engine never removes data on its own.The ttl key is merely advisory.
+        /// When reading a value with a ttl, both the ttl key and the refresh interval will reflect the value:
+        /// </remarks>
+        Task WriteSecretAsync<T>(string path, T data, int? checkAndSet = null, string mountPoint = SecretsEngineDefaultPaths.KeyValueV2);
 
         /// <summary>
         /// Deletes the value at the specified path in Vault.

--- a/src/VaultSharp/V1/SecretsEngines/KeyValue/V2/KeyValueSecretsEngineV2Provider.cs
+++ b/src/VaultSharp/V1/SecretsEngines/KeyValue/V2/KeyValueSecretsEngineV2Provider.cs
@@ -22,6 +22,14 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V2
 
             return await _polymath.MakeVaultApiRequest<Secret<SecretData>>("v1/" + mountPoint.Trim('/') + "/data/" + path.Trim('/') + (version != null ? ("?version=" + version) : ""), HttpMethod.Get, wrapTimeToLive: wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
         }
+        
+        public async Task<Secret<SecretData<T>>> ReadSecretAsync<T>(string path, int? version = null, string mountPoint = SecretsEngineDefaultPaths.KeyValueV2, string wrapTimeToLive = null)
+        {
+            Checker.NotNull(mountPoint, "mountPoint");
+            Checker.NotNull(path, "path");
+
+            return await _polymath.MakeVaultApiRequest<Secret<SecretData<T>>>("v1/" + mountPoint.Trim('/') + "/data/" + path.Trim('/') + (version != null ? ("?version=" + version) : ""), HttpMethod.Get, wrapTimeToLive: wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+        }
 
         public async Task<Secret<FullSecretMetadata>> ReadSecretMetadataAsync(string path, string mountPoint = SecretsEngineDefaultPaths.KeyValueV2, string wrapTimeToLive = null)
         {
@@ -40,6 +48,11 @@ namespace VaultSharp.V1.SecretsEngines.KeyValue.V2
         }
 
         public async Task WriteSecretAsync(string path, IDictionary<string, object> data, int? checkAndSet = null, string mountPoint = SecretsEngineDefaultPaths.KeyValueV2)
+        {
+            await WriteSecretAsync<IDictionary<string, object>>(path, data, checkAndSet, mountPoint);
+        }
+        
+        public async Task WriteSecretAsync<T>(string path, T data, int? checkAndSet = null, string mountPoint = SecretsEngineDefaultPaths.KeyValueV2)
         {
             Checker.NotNull(mountPoint, "mountPoint");
             Checker.NotNull(path, "path");

--- a/test/VaultSharp.Samples/FooData.cs
+++ b/test/VaultSharp.Samples/FooData.cs
@@ -1,0 +1,12 @@
+using Newtonsoft.Json;
+
+namespace VaultSharp.Samples
+{
+    public class FooData
+    {
+        [JsonProperty("foo")]
+        public string Foo { get; set; }
+        [JsonProperty("foo2")]
+        public int Foo2 { get; set; }
+    }
+}

--- a/test/VaultSharp.Samples/Program.cs
+++ b/test/VaultSharp.Samples/Program.cs
@@ -296,6 +296,22 @@ namespace VaultSharp.Samples
             var kv2metadata = _authenticatedVaultClient.V1.Secrets.KeyValue.V2.ReadSecretMetadataAsync(path, mountPoint: kv2SecretsEngine.Path).Result;
             Assert.True(kv2metadata.Data.CurrentVersion > 0); 
 
+
+            // kv2 with generics
+            var genericsPath = "genericBlah";
+            var data = new FooData {Foo = "bar", Foo2 = 42};
+            _authenticatedVaultClient.V1.Secrets.KeyValue.V2.WriteSecretAsync(path, data, mountPoint: kv2SecretsEngine.Path).Wait();
+            
+            var kv2SecretGeneric = _authenticatedVaultClient.V1.Secrets.KeyValue.V2.ReadSecretAsync<FooData>(path, mountPoint: kv2SecretsEngine.Path).Result;
+            Assert.False(string.IsNullOrEmpty(kv2SecretGeneric.Data.Data.Foo));
+            Assert.True(kv2SecretGeneric.Data.Data.Foo2 == 42);
+            
+            var kv2genericmetadata = _authenticatedVaultClient.V1.Secrets.KeyValue.V2.ReadSecretMetadataAsync(genericsPath, mountPoint: kv2SecretsEngine.Path).Result;
+            Assert.True(kv2genericmetadata.Data.CurrentVersion > 0); 
+            
+            _authenticatedVaultClient.V1.Secrets.KeyValue.V2.DestroySecretAsync(genericsPath, new List<int> { kv2genericmetadata.Data.CurrentVersion }, mountPoint: kv2SecretsEngine.Path).Wait();
+
+            
             _authenticatedVaultClient.V1.Secrets.KeyValue.V2.DestroySecretAsync(path, new List<int> { kv2metadata.Data.CurrentVersion }, mountPoint: kv2SecretsEngine.Path).Wait();
 
             _authenticatedVaultClient.V1.System.UnmountSecretBackendAsync(kv2SecretsEngine.Path).Wait();         


### PR DESCRIPTION
Move of https://github.com/rajanadar/VaultSharp/pull/87
---------------------
SecretData was only returning Dictionary<string,object> as the data,
this means consumers of the library would need to map the dicitionary
into objects themselves.

Adding the overload with a generic type.