### PR TITLE
Add ability to use full AuthInfo in CustomAuthMethodInfo. 

### DIFF
--- a/VaultSharp.sln
+++ b/VaultSharp.sln
@@ -14,6 +14,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VaultSharp.UnitTests", "test\VaultSharp.UnitTests\VaultSharp.UnitTests.csproj", "{BD6F4971-34C4-43F1-9128-3DAB4CAA5655}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -28,6 +30,10 @@ Global
 		{66FDCB93-2EA9-46CE-A54C-4B9522CD62E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{66FDCB93-2EA9-46CE-A54C-4B9522CD62E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{66FDCB93-2EA9-46CE-A54C-4B9522CD62E0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BD6F4971-34C4-43F1-9128-3DAB4CAA5655}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BD6F4971-34C4-43F1-9128-3DAB4CAA5655}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BD6F4971-34C4-43F1-9128-3DAB4CAA5655}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BD6F4971-34C4-43F1-9128-3DAB4CAA5655}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,5 +7,5 @@ build_script:
   - cmd: dotnet build
 clone_depth: 1
 test_script:
-  - cmd: dotnet test --filter UnitTests
+  - cmd: cd test\\VaultSharp.UnitTests && dotnet test
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,11 @@
+version: '1.0.{build}'
+image: Visual Studio 2017
+before_build:
+  - cmd: dotnet --version
+  - cmd: dotnet restore --verbosity m
+build_script:
+  - cmd: dotnet build
+clone_depth: 1
+test_script:
+  - cmd: dotnet test
+deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,5 +7,5 @@ build_script:
   - cmd: dotnet build
 clone_depth: 1
 test_script:
-  - cmd: dotnet test
+  - cmd: dotnet test --filter UnitTests
 deploy: off

--- a/src/VaultSharp/AssemblyConfiguration.cs
+++ b/src/VaultSharp/AssemblyConfiguration.cs
@@ -1,0 +1,6 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("VaultSharp.UnitTests,PublicKey=0024000004800000940000000602000000240000525341310004000001000100836503b6fbdcac" +
+                              "ad7b7e8803d511760b60c31b79dc9ecbeb23b792aa1233182b38ebd92c90ab8c16399d5e723f3a" +
+                              "4dc5dc559e9ab2a87272811bd9e6d7d97eb7aa31a258059ac44368d93191ffc13e65852029e375" +
+                              "046d573d0c9f9443299284a425577acc2809cb9d57c1558db6a28b62bab8eefb0631556eb157bd0ec29289")]

--- a/src/VaultSharp/V1/AuthMethods/Custom/CustomAuthMethodInfo.cs
+++ b/src/VaultSharp/V1/AuthMethods/Custom/CustomAuthMethodInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using VaultSharp.Core;
+using VaultSharp.V1.Commons;
 
 namespace VaultSharp.V1.AuthMethods.Custom
 {
@@ -31,17 +32,43 @@ namespace VaultSharp.V1.AuthMethods.Custom
         public Func<Task<string>> AuthenticationTokenAsyncDelegate { get; }
 
         /// <summary>
+        /// Get a delegate that when calling should return whole authentication info. 
+        /// </summary>
+        /// <value>
+        /// The authentication info asynchronous delegate
+        /// </value>
+        public Func<Task<AuthInfo>> AuthenticationInfoAsyncDelegate { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="CustomAuthMethodInfo"/> class.
+        /// Use this way of construction if authentication supports only static token to be resolved.
+        /// WARNING: No token renewal is possible if custom auth is created in way it consumes only token.
         /// </summary>
         /// <param name="type">The type of the unknown authentication backend type not supported by this library yet. e.g. liveid, facebook etc.</param>
         /// <param name="authenticationTokenAsyncDelegate">The authentication token asynchronous delegate.</param>
         public CustomAuthMethodInfo(string type, Func<Task<string>> authenticationTokenAsyncDelegate)
         {
             Checker.NotNull(type, "type");
-            Checker.NotNull(authenticationTokenAsyncDelegate, "authenticationTokenAsyncDelegate");
+            Checker.NotNull(authenticationTokenAsyncDelegate, nameof(authenticationTokenAsyncDelegate));
 
             _lazyAuthMethodType = new Lazy<AuthMethodType>(() => new AuthMethodType(type));
             AuthenticationTokenAsyncDelegate = authenticationTokenAsyncDelegate;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomAuthMethodInfo"/> class.
+        /// Use this way of construction if custom authentication should support token renewal and whole token lifecycle management.
+        /// </summary>
+        /// <param name="type">The type of the unknown authentication backend type not supported by this library yet. e.g. liveid, facebook etc.</param>
+        /// <param name="authenticationInfoAsyncDelegate">The authentication info asynchronous delegate.</param>
+        public CustomAuthMethodInfo(string type, Func<Task<AuthInfo>> authenticationInfoAsyncDelegate)
+            : this(type, async () =>
+            {
+                var authInfo = await authenticationInfoAsyncDelegate();
+                return authInfo?.ClientToken;
+            })
+        {
+            AuthenticationInfoAsyncDelegate = authenticationInfoAsyncDelegate;
         }
     }
 }

--- a/src/VaultSharp/V1/AuthMethods/Custom/CustomAuthMethodLoginProvider.cs
+++ b/src/VaultSharp/V1/AuthMethods/Custom/CustomAuthMethodLoginProvider.cs
@@ -17,14 +17,27 @@ namespace VaultSharp.V1.AuthMethods.Custom
 
         public async Task<string> GetVaultTokenAsync()
         {
-            var token = await _customAuthMethodInfo.AuthenticationTokenAsyncDelegate().ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+            string token;
+            if (_customAuthMethodInfo.AuthenticationInfoAsyncDelegate != null)
+            {
+                var authInfo = await _customAuthMethodInfo.AuthenticationInfoAsyncDelegate()
+                    .ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+                _customAuthMethodInfo.ReturnedLoginAuthInfo = authInfo;
+                token = authInfo?.ClientToken;
+            }
+            else
+            {
+                token = await _customAuthMethodInfo.AuthenticationTokenAsyncDelegate()
+                    .ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+            }
 
             if (!string.IsNullOrWhiteSpace(token))
             {
                 return token;
             }
 
-            throw new Exception("The call to the Custom Auth method did not yield a client token. Please verify your credentials.");
+            throw new Exception(
+                "The call to the Custom Auth method did not yield a client token. Please verify your credentials.");
         }
     }
 }

--- a/test/VaultSharp.UnitTests/V1/AuthMethods/Custom/CustomAuthMethodLoginProviderTests.cs
+++ b/test/VaultSharp.UnitTests/V1/AuthMethods/Custom/CustomAuthMethodLoginProviderTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using VaultSharp.Core;
+using VaultSharp.V1.AuthMethods.Custom;
+using VaultSharp.V1.Commons;
+using Xunit;
+
+namespace VaultSharp.UnitTests.V1.AuthMethods.Custom
+{
+    public class CustomAuthMethodLoginProviderTests
+    {
+        [Fact]
+        public async Task should_get_token_from_delegate()
+        {
+            const string testToken = "test-token";
+            var customAuthInfo = new CustomAuthMethodInfo("test", () => Task.FromResult(testToken));
+
+            CustomAuthMethodLoginProvider loginProvider = GetLoginProvider(customAuthInfo);
+
+            var token = await loginProvider.GetVaultTokenAsync();
+            
+            Assert.Equal(testToken, token);
+        }
+
+        [Fact]
+        public async Task should_set_returned_auth_info_from_delegate_if_auth_info_delegate_is_passed()
+        {
+            const string testToken = "test-token";
+            
+            var authInfo = new AuthInfo
+            {
+                ClientToken = testToken,
+                LeaseDurationSeconds = 100,
+                Renewable = true,
+                Policies = new List<string> { "test-policy" }
+            };
+            
+            var customAuthInfo = new CustomAuthMethodInfo("test", () => Task.FromResult(authInfo));
+
+            CustomAuthMethodLoginProvider loginProvider = GetLoginProvider(customAuthInfo);
+
+            await loginProvider.GetVaultTokenAsync();
+            
+            Assert.Equal(authInfo, customAuthInfo.ReturnedLoginAuthInfo);
+        }
+        
+        [Fact]
+        public async Task should_get_token_from_delegate_if_auth_info_delegate_is_passed()
+        {
+            const string testToken = "test-token";
+            
+            var authInfo = new AuthInfo
+            {
+                ClientToken = testToken,
+                LeaseDurationSeconds = 100,
+                Renewable = true,
+                Policies = new List<string> { "test-policy" }
+            };
+            
+            var customAuthInfo = new CustomAuthMethodInfo("test", () => Task.FromResult(authInfo));
+
+            CustomAuthMethodLoginProvider loginProvider = GetLoginProvider(customAuthInfo);
+
+            var token = await loginProvider.GetVaultTokenAsync();
+            
+            Assert.Equal(testToken, token);
+        }
+        
+        [Fact]
+        public async Task should_throw_exception_when_auth_info_is_null_if_auth_info_delegate_is_passed()
+        {
+            var customAuthInfo = new CustomAuthMethodInfo("test", () => Task.FromResult<AuthInfo>(null));
+
+            CustomAuthMethodLoginProvider loginProvider = GetLoginProvider(customAuthInfo);
+
+            var exception = await Assert.ThrowsAsync<Exception>(() => loginProvider.GetVaultTokenAsync());
+            Assert.Equal("The call to the Custom Auth method did not yield a client token. Please verify your credentials.", exception.Message);
+        }
+        
+        private static CustomAuthMethodLoginProvider GetLoginProvider(CustomAuthMethodInfo customAuthInfo)
+        {
+            var polymath = new Polymath(new VaultClientSettings("http://test-vault", customAuthInfo));
+
+            var loginProvider = new CustomAuthMethodLoginProvider(customAuthInfo, polymath);
+            return loginProvider;
+        }
+    }
+}

--- a/test/VaultSharp.UnitTests/VaultSharp.UnitTests.csproj
+++ b/test/VaultSharp.UnitTests/VaultSharp.UnitTests.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.0;net45</TargetFrameworks>
+    <AssemblyOriginatorKeyFile>../../keys/VaultSharp.snk</AssemblyOriginatorKeyFile>
+    <IsPackable>false</IsPackable>
+    <SignAssembly>true</SignAssembly>
+    <DelaySign>false</DelaySign>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0"/>
+    <PackageReference Include="xunit" Version="2.4.0"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\VaultSharp\VaultSharp.csproj"/>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Copy of https://github.com/rajanadar/VaultSharp/pull/81/

This enables to renew token based on lease duration and other information that is returned in scope of token issue request.

The use-case is next. We have CustomAuthMethodInfo and want to renew token, but renew is done in time authInfo.LeaseDurationInSeconds / 2 and using renew-self method.
In case if just token implementation is used there is no ReturnedLoginAuthInfo which can be used to fetch information about token and be able to effectively renew token