### PR TITLE
Expand the transit backend features

### DIFF
--- a/src/VaultSharp/Core/Polymath.cs
+++ b/src/VaultSharp/Core/Polymath.cs
@@ -126,6 +126,9 @@ namespace VaultSharp.Core
                     httpRequestMessage.Content = requestContent; 
                 }
 
+                if (httpMethod != HttpMethod.Post && httpMethod != HttpMethod.Put && httpMethod != HttpMethod.Options && httpMethod != HttpMethod.Get && !string.Equals(httpMethod.Method, "LIST", StringComparison.OrdinalIgnoreCase))
+                    throw new NotSupportedException("The Http Method is not supported: " + httpMethod);
+
                 if (headers != null)
                 {
                     foreach (var kv in headers)

--- a/src/VaultSharp/Core/Polymath.cs
+++ b/src/VaultSharp/Core/Polymath.cs
@@ -119,45 +119,11 @@ namespace VaultSharp.Core
                     ? new StringContent(JsonConvert.SerializeObject(requestData), Encoding.UTF8)
                     : null;
 
-                HttpRequestMessage httpRequestMessage = null;
+                var httpRequestMessage = new HttpRequestMessage(httpMethod, requestUri);
 
-                switch (httpMethod.ToString().ToUpperInvariant())
+                if (httpMethod == HttpMethod.Post || httpMethod == HttpMethod.Put)
                 {
-                    case "GET":
-
-                        httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
-                        break;
-
-                    case "DELETE":
-
-                        httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, requestUri);
-                        break;
-
-                    case "POST":
-
-                        httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri)
-                        {
-                            Content = requestContent
-                        };
-
-                        break;
-
-                    case "PUT":
-
-                        httpRequestMessage = new HttpRequestMessage(HttpMethod.Put, requestUri)
-                        {
-                            Content = requestContent
-                        };
-
-                        break;
-
-                    case "HEAD":
-
-                        httpRequestMessage = new HttpRequestMessage(HttpMethod.Head, requestUri);
-                        break;
-
-                    default:
-                        throw new NotSupportedException("The Http Method is not supported: " + httpMethod);
+                    httpRequestMessage.Content = requestContent; 
                 }
 
                 if (headers != null)

--- a/src/VaultSharp/V1/SecretsEngines/Transit/ITransitSecretsEngine.cs
+++ b/src/VaultSharp/V1/SecretsEngines/Transit/ITransitSecretsEngine.cs
@@ -9,6 +9,19 @@ namespace VaultSharp.V1.SecretsEngines.Transit
     public interface ITransitSecretsEngine
     {
         /// <summary>
+        /// This endpoint returns a list of keys. 
+        /// Only the key names are returned (not the actual keys themselves).
+        /// </summary>
+        /// <param name="mountPoint"><para>[optional]</para>
+        /// The mount point for the Transit backend. Defaults to <see cref="SecretsEngineDefaultPaths.Transit" />
+        /// Provide a value only if you have customized the mount point.
+        /// </param>
+        /// <returns>
+        /// The key names.
+        /// </returns>
+        Task<Secret<ListResponse>> ListAsync(string mountPoint = SecretsEngineDefaultPaths.Transit);
+
+        /// <summary>
         /// Encrypts the provided plaintext using the named key.
         /// This path supports the create and update policy capabilities as follows: 
         /// if the user has the create capability for this endpoint in their policies, 

--- a/src/VaultSharp/V1/SecretsEngines/Transit/ITransitSecretsEngine.cs
+++ b/src/VaultSharp/V1/SecretsEngines/Transit/ITransitSecretsEngine.cs
@@ -16,10 +16,14 @@ namespace VaultSharp.V1.SecretsEngines.Transit
         /// The mount point for the Transit backend. Defaults to <see cref="SecretsEngineDefaultPaths.Transit" />
         /// Provide a value only if you have customized the mount point.
         /// </param>
+        /// /// <param name="wrapTimeToLive">
+        /// <para>[optional]</para>
+        /// The TTL for the token and can be either an integer number of seconds or a string duration of seconds.
+        /// </param>
         /// <returns>
         /// The key names.
         /// </returns>
-        Task<Secret<ListResponse>> ListAsync(string mountPoint = SecretsEngineDefaultPaths.Transit);
+        Task<Secret<ListResponse>> ListAsync(string mountPoint = SecretsEngineDefaultPaths.Transit, string wrapTimeToLive = null);
 
         /// <summary>
         /// Encrypts the provided plaintext using the named key.

--- a/src/VaultSharp/V1/SecretsEngines/Transit/ITransitSecretsEngine.cs
+++ b/src/VaultSharp/V1/SecretsEngines/Transit/ITransitSecretsEngine.cs
@@ -58,5 +58,28 @@ namespace VaultSharp.V1.SecretsEngines.Transit
         /// The secret with plain text.
         /// </returns>
         Task<Secret<DecryptionResponse>> DecryptAsync(string keyName, DecryptRequestOptions decryptRequestOptions, string mountPoint = SecretsEngineDefaultPaths.Transit, string wrapTimeToLive = null);
+
+        /// <summary>
+        /// Rewraps the provided ciphertext using the latest version of the named key. Because this never returns plaintext, it is possible to delegate this functionality to untrusted users or scripts.
+        /// </summary>
+        /// <param name="keyName">
+        /// [required]
+        /// Specifies the name of the encryption key to re-encrypt against. This is specified as part of the URL.
+        /// </param>
+        /// <param name="rewrapRequestOptions"><para>[required]</para>
+        /// The options.
+        /// </param>
+        /// <param name="mountPoint"><para>[optional]</para>
+        /// The mount point for the Transit backend. Defaults to <see cref="SecretsEngineDefaultPaths.Transit" />
+        /// Provide a value only if you have customized the mount point.
+        /// </param>
+        /// <param name="wrapTimeToLive">
+        /// <para>[optional]</para>
+        /// The TTL for the token and can be either an integer number of seconds or a string duration of seconds.
+        /// </param>
+        /// <returns>
+        /// The secret with plain text.
+        /// </returns>
+        Task<Secret<RewrapResponse>> RewrapAsync(string keyName, RewrapRequestOptions rewrapRequestOptions, string mountPoint = SecretsEngineDefaultPaths.Transit, string wrapTimeToLive = null);
     }
 }

--- a/src/VaultSharp/V1/SecretsEngines/Transit/ListResponse.cs
+++ b/src/VaultSharp/V1/SecretsEngines/Transit/ListResponse.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace VaultSharp.V1.SecretsEngines.Transit
+{
+    /// <summary>
+    /// Represents the list response.
+    /// </summary>
+    public class ListResponse
+    {
+        /// <summary>
+        /// Gets or sets the key names.
+        /// </summary>
+        /// <value>
+        /// The key names.
+        /// </value>
+        public string[] Keys
+        {
+            get; set;
+        }
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/Transit/RewrapItem.cs
+++ b/src/VaultSharp/V1/SecretsEngines/Transit/RewrapItem.cs
@@ -1,0 +1,34 @@
+using Newtonsoft.Json;
+
+namespace VaultSharp.V1.SecretsEngines.Transit
+{
+    /// <summary>
+    /// Represents a single Reawap item.
+    /// </summary>
+    public class RewrapItem
+    {
+        /// <summary>
+        /// [required]
+        /// Specifies cipher text to be decrypted.
+        /// </summary>
+        [JsonProperty("ciphertext")]
+        public string CipherText { get; set; }
+
+        /// <summary>
+        /// [required]
+        ///  Specifies the base64 encoded context for key derivation. 
+        ///  This is required if key derivation is enabled for this key.
+        /// </summary>
+        [JsonProperty("context")]
+        public string Base64EncodedContext { get; set; }
+
+        /// <summary>
+        /// [optional]
+        /// Specifies the base64 encoded nonce value. 
+        /// This must be provided if convergent encryption is enabled for this key and the key was generated with Vault 0.6.1. 
+        /// Not required for keys created in 0.6.2+. 
+        /// </summary>
+        [JsonProperty("nonce")]
+        public string Nonce { get; set; }
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/Transit/RewrapRequestOptions.cs
+++ b/src/VaultSharp/V1/SecretsEngines/Transit/RewrapRequestOptions.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace VaultSharp.V1.SecretsEngines.Transit
+{
+    /// <summary>
+    /// Represents the Decrypt Request Options.
+    /// </summary>
+    public class RewrapRequestOptions : RewrapItem
+    {
+        /// <summary>
+        /// [optional]
+        ///  Specifies the version of the key to use for the operation.
+        ///  If not set, uses the latest version. 
+        ///  Must be greater than or equal to the key's min_encryption_version, if set.
+        /// </summary>
+        [JsonProperty("key_version")]
+        public int? KeyVersion { get; set; }
+
+        /// <summary>
+        /// [optional]
+        /// Specifies a list of items to be rewrapped in a single batch. 
+        /// When this parameter is set, if the parameters 'ciphertext', 'context' and 'nonce' are also set, they will be ignored.
+        /// </summary>
+        [JsonProperty("batch_input")]
+        public List<RewrapItem> BatchedRewrapItems { get; set; }
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/Transit/RewrapResponse.cs
+++ b/src/VaultSharp/V1/SecretsEngines/Transit/RewrapResponse.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace VaultSharp.V1.SecretsEngines.Transit
+{
+    /// <summary>
+    /// Represents the rewrap response.
+    /// </summary>
+    public class RewrapResponse : CipherTextData
+    {
+        /// <summary>
+        /// Gets or sets the batch results.
+        /// </summary>
+        /// <value>
+        /// The batch results.
+        /// </value>
+        [JsonProperty("batch_results")]
+        public List<CipherTextData> BatchedResults
+        {
+            get; set;
+        }
+    }
+}

--- a/src/VaultSharp/V1/SecretsEngines/Transit/TransitKeyType.cs
+++ b/src/VaultSharp/V1/SecretsEngines/Transit/TransitKeyType.cs
@@ -11,7 +11,7 @@ namespace VaultSharp.V1.SecretsEngines.Transit
     public enum TransitKeyType
     {
         /// <summary>
-        /// AES-256 wrapped with GCM using a 12-byte nonce size (symmetric)
+        /// AES-256 wrapped with GCM using a 96-bit nonce size AEAD (symmetric, supports derivation and convergent encryption, default)
         /// </summary>
         [EnumMember(Value = "aes256-gcm96")]
         aes256_gcm96 = 1,
@@ -20,6 +20,48 @@ namespace VaultSharp.V1.SecretsEngines.Transit
         /// ECDSA using the P-256 elliptic curve (asymmetric)
         /// </summary>
         [EnumMember(Value = "ecdsa-p256")]
-        ecdsa_p256 = 2
+        ecdsa_p256 = 2,
+
+        /// <summary>
+        /// AES-128 wrapped with GCM using a 96-bit nonce size AEAD (symmetric, supports derivation and convergent encryption)
+        /// </summary>
+        [EnumMember(Value = "aes128-gcm96")]
+        aes128_gcm96 = 3,
+
+        /// <summary>
+        /// ChaCha20-Poly1305 AEAD (symmetric, supports derivation and convergent encryption)
+        /// </summary>
+        [EnumMember(Value = "chacha20-poly1305")]
+        chacha20_poly1305 = 4,
+
+        /// <summary>
+        /// ED25519 (asymmetric, supports derivation). When using derivation, a sign operation with the same context will derive the same key and signature; this is a signing analogue to `convergent_encryption`.
+        /// </summary>
+        [EnumMember(Value = "ed25519")]
+        ed25519 = 5,
+
+        /// <summary>
+        /// ECDSA using the P-384 elliptic curve (asymmetric)
+        /// </summary>
+        [EnumMember(Value = "ecdsa-p384")]
+        ecdsa_p384 = 6,
+
+        /// <summary>
+        /// ECDSA using the P-521 elliptic curve (asymmetric)
+        /// </summary>
+        [EnumMember(Value = "ecdsa-p521")]
+        ecdsa_p521 = 7,
+
+        /// <summary>
+        /// RSA with bit size of 2048 (asymmetric)
+        /// </summary>
+        [EnumMember(Value = "rsa-2024")]
+        rsa_2048 = 8,
+
+        /// <summary>
+        /// RSA with bit size of 4096 (asymmetric)
+        /// </summary>
+        [EnumMember(Value = "rsa-4096")]
+        rsa_4096 = 9
     }
 }

--- a/src/VaultSharp/V1/SecretsEngines/Transit/TransitSecretsEngineProvider.cs
+++ b/src/VaultSharp/V1/SecretsEngines/Transit/TransitSecretsEngineProvider.cs
@@ -14,9 +14,9 @@ namespace VaultSharp.V1.SecretsEngines.Transit
             _polymath = polymath;
         }
 
-        public async Task<Secret<ListResponse>> ListAsync(string mountPoint = SecretsEngineDefaultPaths.Transit)
+        public async Task<Secret<ListResponse>> ListAsync(string mountPoint = SecretsEngineDefaultPaths.Transit, string wrapTimeToLive = null)
         {
-            return await _polymath.MakeVaultApiRequest<Secret<ListResponse>>("v1/" + mountPoint.Trim('/') + "/keys", new HttpMethod("LIST")).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+            return await _polymath.MakeVaultApiRequest<Secret<ListResponse>>("v1/" + mountPoint.Trim('/') + "/keys", new HttpMethod("LIST"), wrapTimeToLive: wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
         }
 
         public async Task<Secret<EncryptionResponse>> EncryptAsync(string keyName, EncryptRequestOptions encryptRequestOptions, string mountPoint = SecretsEngineDefaultPaths.Transit, string wrapTimeToLive = null)

--- a/src/VaultSharp/V1/SecretsEngines/Transit/TransitSecretsEngineProvider.cs
+++ b/src/VaultSharp/V1/SecretsEngines/Transit/TransitSecretsEngineProvider.cs
@@ -14,6 +14,11 @@ namespace VaultSharp.V1.SecretsEngines.Transit
             _polymath = polymath;
         }
 
+        public async Task<Secret<ListResponse>> ListAsync(string mountPoint = SecretsEngineDefaultPaths.Transit)
+        {
+            return await _polymath.MakeVaultApiRequest<Secret<ListResponse>>("v1/" + mountPoint.Trim('/') + "/keys", new HttpMethod("LIST")).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+        }
+
         public async Task<Secret<EncryptionResponse>> EncryptAsync(string keyName, EncryptRequestOptions encryptRequestOptions, string mountPoint = SecretsEngineDefaultPaths.Transit, string wrapTimeToLive = null)
         {
             Checker.NotNull(keyName, "keyName");

--- a/src/VaultSharp/V1/SecretsEngines/Transit/TransitSecretsEngineProvider.cs
+++ b/src/VaultSharp/V1/SecretsEngines/Transit/TransitSecretsEngineProvider.cs
@@ -25,5 +25,11 @@ namespace VaultSharp.V1.SecretsEngines.Transit
             Checker.NotNull(keyName, "keyName");
             return await _polymath.MakeVaultApiRequest<Secret<DecryptionResponse>>("v1/" + mountPoint.Trim('/') + "/decrypt/" + keyName.Trim('/'), HttpMethod.Post, decryptRequestOptions, wrapTimeToLive: wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
         }
+
+        public async Task<Secret<RewrapResponse>> RewrapAsync(string keyName, RewrapRequestOptions rewrapRequestOptions, string mountPoint = "transit", string wrapTimeToLive = null)
+        {
+            Checker.NotNull(keyName, "keyName");
+            return await _polymath.MakeVaultApiRequest<Secret<RewrapResponse>>("v1/" + mountPoint.Trim('/') + "/rewrap/" + keyName.Trim('/'), HttpMethod.Post, rewrapRequestOptions, wrapTimeToLive: wrapTimeToLive).ConfigureAwait(_polymath.VaultClientSettings.ContinueAsyncTasksOnCapturedContext);
+        }
     }
 }

--- a/test/VaultSharp.Samples/Program.cs
+++ b/test/VaultSharp.Samples/Program.cs
@@ -59,11 +59,11 @@ namespace VaultSharp.Samples
         private static void RunAllSamples()
         {
             // before runnig these tests, just start your local vault server with a file backend.
-            
+
             // startvault.cmd OR these 2 lines.
             // rd E:\raja\work\vault\file_backend /S /Q
             // vault server -config E:\raja\work\vault\f.hcl
-            
+
             // f.hcl looks like
             /*
                 backend "file" {
@@ -192,7 +192,7 @@ namespace VaultSharp.Samples
 
             if (keyNames.Length > 0)
             {
-                var keyName = keyNames[0];                
+                var keyName = keyNames[0];
 
                 var context = "context1";
                 var plainText = "raja";
@@ -326,11 +326,11 @@ namespace VaultSharp.Samples
             Assert.True(paths2.Data.Keys.Count() == 1);
 
             var kv2metadata = _authenticatedVaultClient.V1.Secrets.KeyValue.V2.ReadSecretMetadataAsync(path, mountPoint: kv2SecretsEngine.Path).Result;
-            Assert.True(kv2metadata.Data.CurrentVersion > 0); 
+            Assert.True(kv2metadata.Data.CurrentVersion > 0);
 
             _authenticatedVaultClient.V1.Secrets.KeyValue.V2.DestroySecretAsync(path, new List<int> { kv2metadata.Data.CurrentVersion }, mountPoint: kv2SecretsEngine.Path).Wait();
 
-            _authenticatedVaultClient.V1.System.UnmountSecretBackendAsync(kv2SecretsEngine.Path).Wait();         
+            _authenticatedVaultClient.V1.System.UnmountSecretBackendAsync(kv2SecretsEngine.Path).Wait();
         }
 
         private static void RunSystemBackendSamples()
@@ -1056,7 +1056,7 @@ namespace VaultSharp.Samples
                 rekeyStatus = _unauthenticatedVaultClient.V1.System.GetRekeyStatusAsync().Result;
                 DisplayJson(rekeyStatus);
                 Assert.True(rekeyStatus.Started);
-                Assert.True(rekeyStatus.UnsealKeysProvided == (j+1));
+                Assert.True(rekeyStatus.UnsealKeysProvided == (j + 1));
             }
 
             rekeyProgress = _unauthenticatedVaultClient.V1.System.ContinueRekeyAsync(masterCredentials.MasterKeys[j], rekeyNonce).Result;

--- a/test/VaultSharp.Samples/Program.cs
+++ b/test/VaultSharp.Samples/Program.cs
@@ -217,11 +217,11 @@ namespace VaultSharp.Samples
                 encryptOptions = new EncryptRequestOptions
                 {
                     BatchedEncryptionItems = new List<EncryptionItem>
-                {
-                    new EncryptionItem { Base64EncodedContext = encodedContext, Base64EncodedPlainText = encodedPlainText },
-                    new EncryptionItem { Base64EncodedContext = encodedContext, Base64EncodedPlainText = encodedPlainText },
-                    new EncryptionItem { Base64EncodedContext = encodedContext, Base64EncodedPlainText = encodedPlainText },
-                },
+                    {
+                        new EncryptionItem { Base64EncodedContext = encodedContext, Base64EncodedPlainText = encodedPlainText },
+                        new EncryptionItem { Base64EncodedContext = encodedContext, Base64EncodedPlainText = encodedPlainText },
+                        new EncryptionItem { Base64EncodedContext = encodedContext, Base64EncodedPlainText = encodedPlainText },
+                    },
                     KeyVersion = 1
                 };
 
@@ -242,11 +242,11 @@ namespace VaultSharp.Samples
                 rewrapOptions = new RewrapRequestOptions
                 {
                     BatchedRewrapItems = new List<RewrapItem>
-                {
-                    new RewrapItem { Base64EncodedContext = encodedContext, CipherText = batchedEncryptionResponse.Data.BatchedResults.ElementAt(0).CipherText },
-                    new RewrapItem { Base64EncodedContext = encodedContext, CipherText = batchedEncryptionResponse.Data.BatchedResults.ElementAt(1).CipherText },
-                    new RewrapItem { Base64EncodedContext = encodedContext, CipherText = batchedEncryptionResponse.Data.BatchedResults.ElementAt(2).CipherText },
-                }
+                    {
+                        new RewrapItem { Base64EncodedContext = encodedContext, CipherText = batchedEncryptionResponse.Data.BatchedResults.ElementAt(0).CipherText },
+                        new RewrapItem { Base64EncodedContext = encodedContext, CipherText = batchedEncryptionResponse.Data.BatchedResults.ElementAt(1).CipherText },
+                        new RewrapItem { Base64EncodedContext = encodedContext, CipherText = batchedEncryptionResponse.Data.BatchedResults.ElementAt(2).CipherText },
+                    }
                 };
 
                 var batchedRewrapResponse = _authenticatedVaultClient.V1.Secrets.Transit.RewrapAsync(keyName, rewrapOptions).Result;
@@ -265,11 +265,11 @@ namespace VaultSharp.Samples
                 decryptOptions = new DecryptRequestOptions
                 {
                     BatchedDecryptionItems = new List<DecryptionItem>
-                {
-                    new DecryptionItem { Base64EncodedContext = encodedContext, CipherText = batchedEncryptionResponse.Data.BatchedResults.ElementAt(0).CipherText },
-                    new DecryptionItem { Base64EncodedContext = encodedContext, CipherText = batchedEncryptionResponse.Data.BatchedResults.ElementAt(1).CipherText },
-                    new DecryptionItem { Base64EncodedContext = encodedContext, CipherText = batchedEncryptionResponse.Data.BatchedResults.ElementAt(2).CipherText },
-                }
+                    {
+                        new DecryptionItem { Base64EncodedContext = encodedContext, CipherText = batchedEncryptionResponse.Data.BatchedResults.ElementAt(0).CipherText },
+                        new DecryptionItem { Base64EncodedContext = encodedContext, CipherText = batchedEncryptionResponse.Data.BatchedResults.ElementAt(1).CipherText },
+                        new DecryptionItem { Base64EncodedContext = encodedContext, CipherText = batchedEncryptionResponse.Data.BatchedResults.ElementAt(2).CipherText },
+                    }
                 };
 
                 var batchedDecryptionResponse = _authenticatedVaultClient.V1.Secrets.Transit.DecryptAsync(keyName, decryptOptions).Result;


### PR DESCRIPTION
Right now this PR adds the following Endpoints:
- Rewrap
- List

Planning to add:
- Maybe some from #12 

It also adds all the new Key types supported by the latest version of the transit backend.